### PR TITLE
Add dynamic events pathing, add cwd to yara exclusions

### DIFF
--- a/chirp/plugins/events/events.py
+++ b/chirp/plugins/events/events.py
@@ -14,7 +14,6 @@ from chirp.common import CONSOLE, JSON, OS
 HAS_LIBS = False
 try:
     # cisagov Libraries
-    from chirp.common import OS
     from chirp.plugins.events.evtx2json import iter_evtx2xml, splunkify, xml2json
 
     HAS_LIBS = True
@@ -25,19 +24,25 @@ except ImportError:
 
 PATH = Path(sys.executable)
 
+
 def _path_iterator():
     dirs = ("Sysnative", "System32")
-    for letter in re.findall(r"[A-Z]+:.*$", os.popen("mountvol /").read(), re.MULTILINE): # nosec
+    for letter in re.findall(
+        r"[A-Z]+:.*$", os.popen("mountvol /").read(), re.MULTILINE  # nosec
+    ):
         for d in dirs:
             if os.path.exists(letter + "\\Windows\\{}\\winevt\\Logs".format(d)):
                 return letter + "\\Windows\\{}\\winevt\\Logs\\".format(d) + "{}.evtx"
     return None
 
+
 default_dir = _path_iterator()
 
 if not default_dir:
     if OS == "Windows":
-        CONSOLE("[red][!][/red] We can't find windows event logs at their standard path.")
+        CONSOLE(
+            "[red][!][/red] We can't find windows event logs at their standard path."
+        )
     HAS_LIBS = False
 
 

--- a/chirp/plugins/events/events.py
+++ b/chirp/plugins/events/events.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, Iterator, List, Union
 
 # cisagov Libraries
-from chirp.common import CONSOLE, JSON
+from chirp.common import CONSOLE, JSON, OS
 
 HAS_LIBS = False
 try:
@@ -25,19 +25,19 @@ except ImportError:
 
 PATH = Path(sys.executable)
 
-# Depending on if this is 32bit or 64bit Windows, the logs can be at System32 or Sysnative.
-if os.path.exists(PATH.drive + "\\Windows\\Sysnative\\winevt"):
-    default_dir = PATH.drive + "\\Windows\\Sysnative\\winevt\\Logs\\{}.evtx"
-elif os.path.exists(PATH.drive + "\\Windows\\System32\\winevt"):
-    default_dir = PATH.drive + "\\Windows\\System32\\winevt\\Logs\\{}.evtx"
-else:
-    # TODO: Implement switch
+def _path_iterator():
+    dirs = ("Sysnative", "System32")
+    for letter in re.findall(r"[A-Z]+:.*$", os.popen("mountvol /").read(), re.MULTILINE): # nosec
+        for d in dirs:
+            if os.path.exists(letter + "\\Windows\\{}\\winevt\\Logs".format(d)):
+                return letter + "\\Windows\\{}\\winevt\\Logs\\".format(d) + "{}.evtx"
+    return None
+
+default_dir = _path_iterator()
+
+if not default_dir:
     if OS == "Windows":
-        CONSOLE(
-            "[red][!][/red] We can't find the windows event logs at {}\\System32\\winevt or at {}\\Sysnative\\winevt.".format(
-                PATH.drive, PATH.drive
-            )
-        )
+        CONSOLE("[red][!][/red] We can't find windows event logs at their standard path.")
     HAS_LIBS = False
 
 
@@ -64,11 +64,12 @@ if HAS_LIBS:
         :yield: JSON formatted representation of an event log.
         :rtype: Iterator[JSON]
         """
-        for xml_str in iter_evtx2xml(evtx_file):
-            try:
-                yield splunkify(xml2json(xml_str), source=evtx_file)
-            except:  # noqa: E722
-                pass
+        if os.path.exists(evtx_file):
+            for xml_str in iter_evtx2xml(evtx_file):
+                try:
+                    yield splunkify(xml2json(xml_str), source=evtx_file)
+                except:  # noqa: E722
+                    pass
 
     def t_dict(d: Union[List, Dict]) -> Union[Dict, List]:
         """Given a dictionary, converts the CamelCase keys to snake_case.

--- a/chirp/plugins/yara/run.py
+++ b/chirp/plugins/yara/run.py
@@ -71,7 +71,8 @@ if HAS_LIBS:
         ignorelist = [
             "\\OneDrive\\",
             "\\OneDriveTemp\\",
-        ]  # Ignore these paths, so we don't enumerate cloud drives
+            os.getcwd(),
+        ]  # Ignore these paths, so we don't enumerate cloud drives or our current working directory
         if count % 50000 == 0 and count != 0:
             CONSOLE(
                 "[cyan][YARA][/cyan] We're still working on scanning files. {} processed.".format(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

#1 Adds iteration over drives to find the winevts folder
#5 Catches FileNotFoundError if a specific eventlog doesn't exist
Adds cwd to yara exclusions so certain rules don't catch themselves.

## 💭 Motivation and context ##

Resolves #1 
Resolves #5 

## 🧪 Testing ##

Ran against testing environment.

 Windows 10
 Python 3.7.9 32-bit

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
