### PR TITLE
Add Flexibility for Plugin Selection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd check-your-pulse
-pyenv virtualenv <python_version_to_use> check-your-pulse
-pyenv local check-your-pulse
+cd <repo-dir>
+pyenv virtualenv <python_version_to_use> <repo-dir>
+pyenv local <repo-dir>
 ```
 
 #### Installing the pre-commit hook ####

--- a/README.md
+++ b/README.md
@@ -83,13 +83,21 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 ### From [release](https://github.com/cisagov/chirp/releases)
 
 ```console
+# defaults
 .\chirp.exe
+
+# with args
+.\chirp.exe -p registry -o chirp_result -l debug
 ```
 
 ### From python
 
 ```console
+# defaults 
 python3 chirp.py
+
+# with args
+python3 chirp.py -p registry -o chirp_result -l debug
 ```
 
 ### Example output

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 ### From python
 
 ```console
-# defaults 
+# defaults
 python3 chirp.py
 
 # with args

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -26,8 +26,12 @@ parser.add_argument(
     help="Log level. Info, Error, Critical, or Debug.",
     default="silent",
 )
+parser.add_argument(
+    "-p", "--plugins", nargs="*", help="Specified plugins to run.", default="all"
+)
 ARGS, _ = parser.parse_known_args()
 OUTPUT_DIR = ARGS.output
+PLUGINS = ARGS.plugins
 
 
 def _sinkhole(*args, **kwargs) -> None:

--- a/chirp/plugins/loader.py
+++ b/chirp/plugins/loader.py
@@ -3,7 +3,7 @@
 # Standard Python Libraries
 import importlib
 import pkgutil
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
 # cisagov Libraries
 from chirp.common import ADMIN, DEBUG, ERROR, INFO, OS
@@ -76,16 +76,16 @@ def _loader(name: str, discovered_plugins: Dict[str, Callable]) -> None:
         ERROR("{} does not have a valid entrypoint".format(name))
 
 
-def load() -> Dict[str, Callable]:
+def load(plugins: List[str]) -> Dict[str, Callable]:
     """Load plugins discovered in the plugins directory.
 
     :return: A dictionary with a key of the plugin name and a value of the entrypoint.
     :rtype: Dict[str, Callable]
     """
-    DEBUG("Starting plugin loader.")
+    DEBUG("Starting plugin loader. Loading plugins: {}".format(plugins))
     discovered_plugins = {}
     for _, name, ispkg in pkgutil.iter_modules(path=["chirp/plugins"]):
-        if ispkg:
+        if ispkg and ((name in plugins) or ("all" in plugins)):
             _loader(name, discovered_plugins)
     DEBUG("Finished loading plugins.")
     return discovered_plugins

--- a/chirp/run.py
+++ b/chirp/run.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Iterable, Iterator, List
 
 # cisagov Libraries
 from chirp import load
-from chirp.common import CRITICAL, DEBUG, ERROR, OUTPUT_DIR
+from chirp.common import CRITICAL, DEBUG, ERROR, OUTPUT_DIR, PLUGINS
 from chirp.plugins import events, loader, network, registry, yara  # noqa: F401
 
 
@@ -15,8 +15,8 @@ def run() -> None:
     """Run plugins and write out output."""
     if not os.path.exists(OUTPUT_DIR):
         os.mkdir(OUTPUT_DIR)
-    plugins = loader.load()
-    run_plugins(plugins)
+    loaded_plugins = loader.load(PLUGINS)
+    run_plugins(loaded_plugins)
 
 
 def run_plugins(plugins: Dict[str, Callable]) -> None:
@@ -72,7 +72,8 @@ def check_valid_indicator_types(
             yield indicator
             DEBUG("Loaded {}".format(indicator["name"]))
         else:
-            if indicator["ioc_type"] not in failed_types:
+            if ((indicator["ioc_type"] in plugins or "all" in plugins)
+                and indicator["ioc_type"] not in failed_types):
                 ERROR(
                     """Can't locate plugin "{}". It is possible it has not loaded due to an error.""".format(
                         indicator["ioc_type"]

--- a/chirp/run.py
+++ b/chirp/run.py
@@ -72,8 +72,9 @@ def check_valid_indicator_types(
             yield indicator
             DEBUG("Loaded {}".format(indicator["name"]))
         else:
-            if ((indicator["ioc_type"] in plugins or "all" in plugins)
-            and indicator["ioc_type"] not in failed_types):
+            if (indicator["ioc_type"] in plugins or "all" in plugins) and indicator[
+                "ioc_type"
+            ] not in failed_types:
                 ERROR(
                     """Can't locate plugin "{}". It is possible it has not loaded due to an error.""".format(
                         indicator["ioc_type"]

--- a/chirp/run.py
+++ b/chirp/run.py
@@ -73,7 +73,7 @@ def check_valid_indicator_types(
             DEBUG("Loaded {}".format(indicator["name"]))
         else:
             if ((indicator["ioc_type"] in plugins or "all" in plugins)
-                and indicator["ioc_type"] not in failed_types):
+            and indicator["ioc_type"] not in failed_types):
                 ERROR(
                     """Can't locate plugin "{}". It is possible it has not loaded due to an error.""".format(
                         indicator["ioc_type"]


### PR DESCRIPTION
# Add Flexibility for Plugin Selection #

## 🗣 Description ##

Adds flexibility to select specific CISA CHIRP plugins at runtime.

## 💭 Motivation and context ##

In general, really impressed and grateful for the work on CHIRP from CISA!

I think the related changes might be helpful because:
- Specific environments or use-cases may not require or benefit each plugin to run.
- Running all plugins when some are not needed involves additional and unnecessary time.

## 🧪 Testing ##

- Ran pre-commit checks as specified in repo:
```shell
pre-commit run --all-files
```

- After checking out the code related to this PR, one may test using the following:
```shell
cd CHIRP

# run only registry and network plugins with debug logging
python chirp.py -p registry network -l debug

# run only registry and network plugins with output dir set to "chirp_result" and debug logging
python chirp.py -p registry -o chirp_result -l debug

# run all plugins with debug logging
python chirp.py -l debug
```

## 📷 Screenshots (if appropriate) ##

n/a

## ✅ Checklist ##

Appreciate any guidance or suggestions on unchecked (or checked!) boxes below. 👍 

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [ ] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
