### PR TITLE
Add Target Filepaths Argument for Yara Plugin IOC Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 .\chirp.exe
 
 # with args
-.\chirp.exe -p registry -o chirp_result -l debug
+.\chirp.exe -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
 ```
 
 ### From python
@@ -97,7 +97,7 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 python3 chirp.py
 
 # with args
-python3 chirp.py -p registry -o chirp_result -l debug
+python3 chirp.py -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
 ```
 
 ### Example output

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -14,8 +14,7 @@ from rich.console import Console
 from rich.traceback import install
 
 parser = argparse.ArgumentParser(
-    prog="CHIRP",
-    description="CHIRP. A Window host forensic artifact collection tool.",
+    prog="CHIRP", description="CHIRP. A Window host forensic artifact collection tool.",
 )
 parser.add_argument(
     "-o", "--output", help="Specified output directory.", default="output"
@@ -29,9 +28,17 @@ parser.add_argument(
 parser.add_argument(
     "-p", "--plugins", nargs="*", help="Specified plugins to run.", default="all"
 )
+parser.add_argument(
+    "-t",
+    "--targets",
+    nargs="*",
+    help="Specified override filepath targets for yara plugin indicators.",
+    default=None,
+)
 ARGS, _ = parser.parse_known_args()
 OUTPUT_DIR = ARGS.output
 PLUGINS = ARGS.plugins
+TARGETS = ARGS.targets
 
 
 def _sinkhole(*args, **kwargs) -> None:

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -14,7 +14,8 @@ from rich.console import Console
 from rich.traceback import install
 
 parser = argparse.ArgumentParser(
-    prog="CHIRP", description="CHIRP. A Window host forensic artifact collection tool.",
+    prog="CHIRP",
+    description="CHIRP. A Window host forensic artifact collection tool.",
 )
 parser.add_argument(
     "-o", "--output", help="Specified output directory.", default="output"

--- a/chirp/plugins/yara/run.py
+++ b/chirp/plugins/yara/run.py
@@ -10,7 +10,7 @@ import re
 from typing import Any, Dict, Iterator, Tuple, Union
 
 # cisagov Libraries
-from chirp.common import CONSOLE, OS, OUTPUT_DIR, build_report
+from chirp.common import CONSOLE, OS, OUTPUT_DIR, TARGETS, build_report
 
 try:
     # Third-Party Libraries
@@ -112,8 +112,12 @@ if HAS_LIBS:
 
         CONSOLE("[cyan][YARA][/cyan] Entered yara plugin.")
 
-        files = [i["indicator"]["files"] for i in indicators]
+        files = (
+            [i["indicator"]["files"] for i in indicators] if not TARGETS else TARGETS
+        )
         files = "\\**" if "\\**" in files else ", ".join(files)
+
+        CONSOLE("[cyan][YARA][/cyan] Yara targets: {}".format(files))
 
         if files == "\\**":
             blame = [i["name"] for i in indicators if i["indicator"]["files"] == "\\**"]


### PR DESCRIPTION
# Add Target Filepaths Argument for Yara Plugin IOC Override #

## 🗣 Description ##

Adds target filepath argument for CISA CHIRP which overrides IOC "files" specifications at runtime to increase tool flexibility and performance where desired.

## 💭 Motivation and context ##

All Yara-based indicators currently use `"\\**"` as their files specification which may cause impossible runtime completion in virtual or containerized environments where hardware resources are scarce. The code related to this PR seeks to introduce a new argument which overrides Yara IOC files specifications to help ensure CISA CHIRP Yara plugin completion within these specialized environments (or others, as applicable). There may also be utility in this functionality beyond solely these environments, for instance scenarios where quick insights on specific targets are required or highly valued.

## 🧪 Testing ##

As indicated by documentation and video, default CISA CHIRP may take anywhere from 1 to 2 hours to complete (or more). Using specific Yara target paths has the possibility of greatly reducing this performance time, depending on the size and amount of files in targets.

- Ran pre-commit checks as specified in repo:
```shell
pre-commit run --all-files
```

- After checking out the code related to this PR, one may test using the following:
```shell
cd CHIRP

# run only yara plugin and target c:\\users\\** with debug logging
python chirp.py -p yara -t c:\\users\\** -l debug

# run only yara plugin and target c:\\users\\** and "c:\\Program Files\\**" with debug logging
python chirp.py -p yara -t c:\\users\\** "c:\\Program Files\\**" -l debug

# run all plugins (defaulting to Yara IOC files specifications) with debug logging
python chirp.py -l debug
```

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
