### PR TITLE
V1.0.4

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -15,10 +15,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version_scheme: semantic
 
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: 3.8
+          architecture: x64
+
       - name: Compile
         run: |
-          py -m pip install -e .
-          py -m nuitka --onefile chirp.py --windows-onefile-tempdir --plugin-enable=multiprocessing --plugin-enable=pylint-warnings --windows-uac-admin --assume-yes-for-downloads --windows-icon-from-ico=.\assets\CISA_Logo.ico
+          python -m pip install -e .
+          python -m nuitka --onefile chirp.py --windows-onefile-tempdir --plugin-enable=multiprocessing --plugin-enable=pylint-warnings --windows-uac-admin --assume-yes-for-downloads --windows-icon-from-ico=.\assets\CISA_Logo.ico --msvc=14.2
 
       - name: Hash
         id: hash

--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -14,13 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Requirements
-        run: |
-          py -m pip install -e .
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: 3.8
+          architecture: x64
 
       - name: Compile
         run: |
-          py -m nuitka --onefile chirp.py --windows-onefile-tempdir --plugin-enable=multiprocessing --plugin-enable=pylint-warnings --windows-uac-admin --assume-yes-for-downloads --windows-icon-from-ico=.\assets\CISA_Logo.ico
+          python -m pip install -e .
+          python -m nuitka --onefile chirp.py --windows-onefile-tempdir --plugin-enable=multiprocessing --plugin-enable=pylint-warnings --windows-uac-admin --assume-yes-for-downloads --windows-icon-from-ico=.\assets\CISA_Logo.ico --msvc=14.2
 
       - name: Bundle
         run: |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 .\chirp.exe
 
 # with args
-.\chirp.exe -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
+.\chirp.exe -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug --non-interactive
 ```
 
 ### From python
@@ -97,7 +97,7 @@ with [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/)
 python3 chirp.py
 
 # with args
-python3 chirp.py -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
+python3 chirp.py -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug --non-interactive
 ```
 
 ### Example output

--- a/chirp.py
+++ b/chirp.py
@@ -8,7 +8,7 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log
+from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log, wait
 
 if __name__ == "__main__":
     try:
@@ -16,11 +16,11 @@ if __name__ == "__main__":
         run.run()
         time.sleep(2)
         CONSOLE(
-            "[green][+][/green] DONE! Your results can be found in {}. Press any key to exit.".format(
+            "[green][+][/green] DONE! Your results can be found in {}.".format(
                 os.path.abspath(OUTPUT_DIR)
             )
         )
-        input()
+        wait()
         save_log()
         sys.exit(0)
     except KeyboardInterrupt:

--- a/chirp/__main__.py
+++ b/chirp/__main__.py
@@ -8,7 +8,7 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log
+from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log, wait
 
 if __name__ == "__main__":
     try:
@@ -16,11 +16,11 @@ if __name__ == "__main__":
         run.run()
         time.sleep(2)
         CONSOLE(
-            "[green][+][/green] DONE! Your results can be found in {}. Press any key to exit.".format(
+            "[green][+][/green] DONE! Your results can be found in {}.".format(
                 os.path.abspath(OUTPUT_DIR)
             )
         )
-        input()
+        wait()
         save_log()
         sys.exit(0)
     except KeyboardInterrupt:

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -36,6 +36,11 @@ parser.add_argument(
     help="Specified override filepath targets for yara plugin indicators.",
     default=None,
 )
+parser.add_argument(
+    "--non-interactive",
+    help="Run in non-interactive mode (close after completion)",
+    action="store_true",
+)
 ARGS, _ = parser.parse_known_args()
 OUTPUT_DIR = ARGS.output
 PLUGINS = ARGS.plugins
@@ -138,3 +143,17 @@ def build_report(indicator: dict) -> dict:
 def save_log() -> None:
     """Save the log output to `chirp.log`."""
     _CONSOLE.save_text("chirp.log")
+
+
+def wait() -> None:
+    """
+    Wait for a keypress to continue.
+
+    Reference: `CrouZ, StackOverflow <https://stackoverflow.com/a/16933120>`_
+    """
+    if not ARGS.non_interactive:
+        if OS == "Windows":
+            os.system("pause")  # nosec
+        else:
+            os.system('read -s -n 1 -p "Press any key to continue..."')  # nosec
+            print()

--- a/chirp/plugins/events/events.py
+++ b/chirp/plugins/events/events.py
@@ -14,9 +14,6 @@ from chirp.common import CONSOLE, JSON, OS
 
 HAS_LIBS = False
 try:
-    # Standard Python Libraries
-    from ctypes import windll
-
     # cisagov Libraries
     from chirp.plugins.events.evtx2json import iter_evtx2xml, splunkify, xml2json
 
@@ -25,6 +22,10 @@ except ImportError:
     CONSOLE(
         "[red][!][/red] python-evtx, dict-toolbox, and xmljson are required dependencies for the events plugin. Please install requirements with pip."
     )
+
+if OS == "Windows":
+    # Standard Python Libraries
+    from ctypes import windll
 
 PATH = Path(sys.executable)
 

--- a/chirp/plugins/yara/run.py
+++ b/chirp/plugins/yara/run.py
@@ -7,7 +7,7 @@ import itertools
 import json
 import os
 import string
-from typing import Any, Dict, Iterator, Tuple, Union, List
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
 # cisagov Libraries
 from chirp.common import CONSOLE, OS, OUTPUT_DIR, TARGETS, build_report
@@ -22,6 +22,7 @@ except ImportError:
     HAS_LIBS = False
 
 if OS == "Windows":
+    # Standard Python Libraries
     from ctypes import windll
 
 
@@ -39,6 +40,7 @@ def _get_drives() -> List[str]:
         bitmask >>= 1
 
     return drives
+
 
 def normalize_paths(path: str) -> Iterator[str]:
     """Normalize paths in the yara query.

--- a/chirp/plugins/yara/run.py
+++ b/chirp/plugins/yara/run.py
@@ -6,8 +6,8 @@ from glob import glob
 import itertools
 import json
 import os
-import re
-from typing import Any, Dict, Iterator, Tuple, Union
+import string
+from typing import Any, Dict, Iterator, Tuple, Union, List
 
 # cisagov Libraries
 from chirp.common import CONSOLE, OS, OUTPUT_DIR, TARGETS, build_report
@@ -21,6 +21,24 @@ try:
 except ImportError:
     HAS_LIBS = False
 
+if OS == "Windows":
+    from ctypes import windll
+
+
+def _get_drives() -> List[str]:
+    """
+    Return a list of valid drives.
+
+    Reference: `RichieHindle, StackOverflow <https://stackoverflow.com/a/827398>`_
+    """
+    drives = []
+    bitmask = windll.kernel32.GetLogicalDrives()
+    for letter in string.ascii_uppercase:
+        if bitmask & 1:
+            drives.append(letter)
+        bitmask >>= 1
+
+    return drives
 
 def normalize_paths(path: str) -> Iterator[str]:
     """Normalize paths in the yara query.
@@ -31,10 +49,8 @@ def normalize_paths(path: str) -> Iterator[str]:
     :rtype: Iterator[str]
     """
     if OS == "Windows" and path == "\\**":
-        for letter in re.findall(
-            r"[A-Z]+:.*$", os.popen("mountvol /").read(), re.MULTILINE  # nosec
-        ):
-            yield from normalize_paths(letter + "**")
+        for letter in _get_drives():
+            yield from normalize_paths(letter + ":\\**")
     elif "*" in path:
         yield from [p for p in glob(path, recursive=True) if os.path.exists(p)]
     if "," in path:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

#20 - Provides a `--non-interactive` switch and actually accepts any key to exit.
#22 - Properly catches cases when not ran on Windows, removes mountvol as dependency.
#13 - Compiling with mvsc and python3.8 should remove some unknowns
#4  - Changing the python dll to 3.8 should allow CHIRP to run on Server 2008 R2.

## 💭 Motivation and context ##

Resolves #20 
Resolves #22

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested in development environment:
Windows 10
Python 3.8
VSCode

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
