### PR TITLE
v1.0.5

### DIFF
--- a/chirp.py
+++ b/chirp.py
@@ -1,6 +1,7 @@
 """Main script entrypoint for CHIRP."""
 
 # Standard Python Libraries
+import logging
 from multiprocessing import freeze_support
 import os
 import sys
@@ -8,22 +9,21 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log, wait
+from chirp.common import OUTPUT_DIR, save_log, wait
 
 if __name__ == "__main__":
     try:
         freeze_support()
         run.run()
         time.sleep(2)
-        CONSOLE(
-            "[green][+][/green] DONE! Your results can be found in {}.".format(
-                os.path.abspath(OUTPUT_DIR)
-            )
+        logging.log(
+            70,
+            "DONE! Your results can be found in {}".format(os.path.abspath(OUTPUT_DIR)),
         )
         wait()
         save_log()
         sys.exit(0)
     except KeyboardInterrupt:
-        ERROR("Received an escape sequence. Goodbye.")
+        logging.error("Received an escape sequence. Goodbye.")
         save_log()
         sys.exit(0)

--- a/chirp/__main__.py
+++ b/chirp/__main__.py
@@ -1,6 +1,7 @@
 """Main method for CHIRP (Used when compiled)."""
 
 # Standard Python Libraries
+import logging
 from multiprocessing import freeze_support
 import os
 import sys
@@ -8,22 +9,23 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, save_log, wait
+from chirp.common import OUTPUT_DIR, save_log, wait
 
 if __name__ == "__main__":
     try:
         freeze_support()
         run.run()
         time.sleep(2)
-        CONSOLE(
-            "[green][+][/green] DONE! Your results can be found in {}.".format(
+        logging.log(
+            70,
+            "DONE! Your results can be found in {}.".format(
                 os.path.abspath(OUTPUT_DIR)
-            )
+            ),
         )
         wait()
         save_log()
         sys.exit(0)
     except KeyboardInterrupt:
-        ERROR("Received an escape sequence. Goodbye.")
+        logging.error("Received an escape sequence. Goodbye.")
         save_log()
         sys.exit(0)

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -3,15 +3,14 @@
 # Standard Python Libraries
 import argparse
 import ctypes
+import logging
 import os
-import queue
 import sys
-import threading
 import typing as t
 
 # Third-Party Libraries
 from rich.console import Console
-from rich.traceback import install
+from rich.logging import RichHandler
 
 parser = argparse.ArgumentParser(
     prog="CHIRP",
@@ -19,12 +18,6 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument(
     "-o", "--output", help="Specified output directory.", default="output"
-)
-parser.add_argument(
-    "-l",
-    "--log-level",
-    help="Log level. Info, Error, Critical, or Debug.",
-    default="silent",
 )
 parser.add_argument(
     "-p", "--plugins", nargs="*", help="Specified plugins to run.", default="all"
@@ -38,18 +31,52 @@ parser.add_argument(
 )
 parser.add_argument(
     "--non-interactive",
-    help="Run in non-interactive mode (close after completion)",
+    help="Run in non-interactive mode (close after completion).",
     action="store_true",
+)
+parser.add_argument(
+    "--silent",
+    help="Silence CHIRP output.",
+    action="store_true",
+)
+parser.add_argument(
+    "-v",
+    "--verbose",
+    action="count",
+    default=0,
+    help="program verbosity, use more `v`s to increase verbosity, default is no verbosity.",
 )
 ARGS, _ = parser.parse_known_args()
 OUTPUT_DIR = ARGS.output
 PLUGINS = ARGS.plugins
 TARGETS = ARGS.targets
 
+if ARGS.verbose >= 2:
+    LOG_LEVEL = logging.NOTSET
+elif ARGS.verbose == 1:
+    LOG_LEVEL = logging.INFO
+else:
+    LOG_LEVEL = logging.ERROR
 
-def _sinkhole(*args, **kwargs) -> None:
-    """Drop any input and return nothing."""
-    pass
+if ARGS.silent:
+    LOG_LEVEL = 100
+
+_CONSOLE = Console(record=True)
+
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format="%(message)s",
+    datefmt="%X",
+    handlers=[
+        RichHandler(rich_tracebacks=True, tracebacks_show_locals=True, console=_CONSOLE)
+    ],
+)
+
+logging.addLevelName(60, "EVENTS")
+logging.addLevelName(61, "REGISTRY")
+logging.addLevelName(62, "YARA")
+logging.addLevelName(63, "NETWORK")
+logging.addLevelName(70, "COMPLETE")
 
 
 def _is_admin():
@@ -76,55 +103,17 @@ def _get_platform():
         return "UNSUPPORTED"
 
 
-_CONSOLE = Console(record=True)
-
-_console_queue = queue.Queue()
-
-CONSOLE = lambda x: _console_queue.put(x)
-_INFO = lambda x: _console_queue.put("[green][+][/green] {}".format(x))
-_ERROR = lambda x: _console_queue.put("[red][-][/red] {}".format(x))
-_CRITICAL = lambda x: _console_queue.put("[cyan][!][/cyan] {}".format(x))
-_DEBUG = lambda x: _console_queue.put("[yellow][?][/yellow] {}".format(x))
-
-"""
-A workaround to log levels, gives us greater control in the main program.
-This mapping allows the user to specify a log level (debug, critical, error, info, silent).
-Based on the user input, functions are returned matching the desired output,
-sinkhole() is as it sounds, a method to capture input and output nothing,
-which effectively allows us to void calls like ERROR("some error text") as
-sinkhole will capture the input and return None.
-"""
-log_levels = {
-    "debug": [_INFO, _ERROR, _CRITICAL, _DEBUG],
-    "critical": [_INFO, _ERROR, _CRITICAL, _sinkhole],
-    "error": [_INFO, _ERROR, _sinkhole, _sinkhole],
-    "info": [_INFO, _sinkhole, _sinkhole, _sinkhole],
-    "silent": [_sinkhole, _sinkhole, _sinkhole, _sinkhole],
-}
-
-INFO, ERROR, CRITICAL, DEBUG = log_levels[ARGS.log_level.lower()]
+CONSOLE = lambda x: logging.warning(x)
+INFO = lambda x: logging.info(x)
+ERROR = lambda x: logging.error(x)
+CRITICAL = lambda x: logging.critical(x)
+DEBUG = lambda x: logging.debug(x)
 
 # https://github.com/python/typing/issues/182
 JSON = t.Union[str, int, float, bool, None, t.Mapping[str, "JSON"], t.List["JSON"]]
 
 ADMIN = _is_admin()
 OS = _get_platform()
-
-# Install traceback handler
-install()
-
-
-def _logger():
-    """Use a queue to prevent async functions from writing to the console at the same time. Sleep for 2 seconds then checks if there is data to write out."""
-    if _console_queue:
-        while not _console_queue.empty():
-            _CONSOLE.log(_console_queue.get())
-    _thread = threading.Timer(interval=2, function=_logger)
-    _thread.daemon = True
-    _thread.start()
-
-
-_logger()
 
 
 def build_report(indicator: dict) -> dict:

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -103,12 +103,6 @@ def _get_platform():
         return "UNSUPPORTED"
 
 
-CONSOLE = lambda x: logging.warning(x)
-INFO = lambda x: logging.info(x)
-ERROR = lambda x: logging.error(x)
-CRITICAL = lambda x: logging.critical(x)
-DEBUG = lambda x: logging.debug(x)
-
 # https://github.com/python/typing/issues/182
 JSON = t.Union[str, int, float, bool, None, t.Mapping[str, "JSON"], t.List["JSON"]]
 

--- a/chirp/load.py
+++ b/chirp/load.py
@@ -1,13 +1,11 @@
 """Provides methods for loading indicator files."""
 
 # Standard Python Libraries
+import logging
 from typing import Iterator, List
 
 # Third-Party Libraries
 import yaml
-
-# cisagov Libraries
-from chirp.common import CRITICAL, DEBUG
 
 
 def from_yaml(file_paths: List[str]) -> Iterator[dict]:
@@ -18,10 +16,10 @@ def from_yaml(file_paths: List[str]) -> Iterator[dict]:
     :yield: A dict representation of a yaml file.
     :rtype: Iterator[dict]
     """
-    DEBUG("Started indicator loader.")
+    logging.debug("Started indicator loader.")
     for indicator in file_paths:
         try:
             yield from yaml.safe_load_all(open(indicator, encoding="utf8").read())
         except (TypeError, UnicodeDecodeError):
-            CRITICAL("Had an issue parsing {}".format(indicator))
-    DEBUG("Finished loading indicators.")
+            logging.critical("Had an issue parsing {}".format(indicator))
+    logging.debug("Finished loading indicators.")

--- a/chirp/plugins/events/events.py
+++ b/chirp/plugins/events/events.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 from functools import lru_cache
+import logging
 import os
 from pathlib import Path
 import re
@@ -10,7 +11,7 @@ import sys
 from typing import Any, Dict, Iterator, List, Union
 
 # cisagov Libraries
-from chirp.common import CONSOLE, JSON, OS
+from chirp.common import JSON, OS
 
 HAS_LIBS = False
 try:
@@ -19,8 +20,8 @@ try:
 
     HAS_LIBS = True
 except ImportError:
-    CONSOLE(
-        "[red][!][/red] python-evtx, dict-toolbox, and xmljson are required dependencies for the events plugin. Please install requirements with pip."
+    logging.error(
+        "(EVENTS) python-evtx, dict-toolbox, and xmljson are required dependencies for the events plugin. Please install requirements with pip."
     )
 
 if OS == "Windows":
@@ -63,9 +64,7 @@ default_dir = _path_iterator()
 
 if not default_dir:
     if OS == "Windows":
-        CONSOLE(
-            "[red][!][/red] We can't find windows event logs at their standard path."
-        )
+        logging.log(60, "We can't find windows event logs at their standard path.")
     HAS_LIBS = False
 
 

--- a/chirp/plugins/events/evtx2json.py
+++ b/chirp/plugins/events/evtx2json.py
@@ -34,20 +34,7 @@ import xml.etree.ElementTree as ET  # nosec
 import Evtx.Evtx as evtx
 from xmljson import badgerfish as bf
 
-# cisagov Libraries
-from chirp.common import CONSOLE
-
-logger = logging.getLogger("evtx2json")
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-stream_handler.level = logging.INFO
-formatter = logging.Formatter(
-    fmt="%(asctime)s [%(name)10s] %(levelname)s %(message)s",
-    datefmt="%m/%d/%y %I:%M:%S %p",
-)
-stream_handler.formatter = formatter
-logger.addHandler(stream_handler)
+logger = logging.getLogger()
 
 # Additional fields for Splunk indexing
 fields = dict({})
@@ -169,9 +156,7 @@ def iter_evtx2xml(evtx_file):
     except Exception as err:
         raise
     if error_counter:
-        CONSOLE(
-            "[cyan][evtx2json][/cyan] Failed to read {} events.".format(error_counter)
-        )
+        logging.error("Failed to read {} events.".format(error_counter))
 
 
 def _transform_system(output):

--- a/chirp/plugins/events/scan.py
+++ b/chirp/plugins/events/scan.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 import json
+import logging
 import os
 from typing import Dict, List, Tuple, Union
 
@@ -9,7 +10,7 @@ from typing import Dict, List, Tuple, Union
 import aiomultiprocess as aiomp
 
 # cisagov Libraries
-from chirp.common import CONSOLE, OUTPUT_DIR, build_report
+from chirp.common import OUTPUT_DIR, build_report
 from chirp.plugins import operators
 from chirp.plugins.events.events import gather
 
@@ -65,14 +66,10 @@ async def _run(run_args):
         report,
         num_logs,
     ) = run_args  # Unpack our arguments (bundled to passthrough for multiprocessing)
-    CONSOLE(
-        "[cyan][EVENTS][/cyan] Reading {} event logs.".format(
-            event_type.split("%4")[-1]
-        )
-    )
+    logging.log(60, "Reading {} event logs.".format(event_type.split("%4")[-1]))
     async for event_log in gather(event_type):  # Iterate over event logs
         if event_log == "ERROR":
-            CONSOLE("[cyan][EVENTS][/cyan] Hit an error, exiting.")
+            logging.log(60, "Hit an error, exiting.")
             return
         if event_log:
             num_logs += 1
@@ -117,7 +114,7 @@ async def run(indicators: dict) -> None:
         return
     hits = 0
     num_logs = 0
-    CONSOLE("[cyan][EVENTS][/cyan] Entered events plugin.")
+    logging.debug("Entered events plugin.")
     event_types = {indicator["indicator"]["event_type"] for indicator in indicators}
     report = {indicator["name"]: build_report(indicator) for indicator in indicators}
     run_args = [
@@ -138,9 +135,7 @@ async def run(indicators: dict) -> None:
             pass
 
     hits = sum(len(v["matches"]) for _, v in report.items())
-    CONSOLE(
-        "[cyan][EVENTS][/cyan] Read {} logs, found {} matches.".format(num_logs, hits)
-    )
+    logging.log(60, "Read {} logs, found {} matches.".format(num_logs, hits))
     with open(os.path.join(OUTPUT_DIR, "events.json"), "w+") as writeout:
         writeout.write(
             json.dumps({r: report[r] for r in report if report[r]["matches"]})

--- a/chirp/plugins/network/scan.py
+++ b/chirp/plugins/network/scan.py
@@ -2,11 +2,12 @@
 
 # Standard Python Libraries
 import json
+import logging
 import os
 from typing import List
 
 # cisagov Libraries
-from chirp.common import CONSOLE, ERROR, OUTPUT_DIR, build_report
+from chirp.common import OUTPUT_DIR, build_report
 from chirp.plugins.network.network import (
     grab_dns,
     grab_netstat,
@@ -38,7 +39,7 @@ async def run(indicators: dict) -> None:
         return
 
     hits = 0
-    CONSOLE("[cyan][NETWORK][/cyan] Entered network plugin.")
+    logging.debug("Entered network plugin.")
     saved_ns = parse_netstat(grab_netstat())
     saved_dns = parse_dns(grab_dns())
 
@@ -51,11 +52,12 @@ async def run(indicators: dict) -> None:
                     report[indicator["name"]]["matches"].append(ioc)
                     hits += 1
         except KeyError:
-            ERROR("{} appears to be malformed.".format(indicator))
-    CONSOLE(
-        "[cyan][NETWORK][/cyan] Read {} records, found {} IoC hits.".format(
+            logging.log(63, "{} appears to be malformed.".format(indicator))
+    logging.log(
+        63,
+        "Read {} records, found {} IoC hits.".format(
             len(saved_dns) + len(saved_ns), hits
-        )
+        ),
     )
 
     with open(os.path.join(OUTPUT_DIR, "network.json"), "w+") as writeout:

--- a/chirp/plugins/operators.py
+++ b/chirp/plugins/operators.py
@@ -2,11 +2,9 @@
 
 # Standard Python Libraries
 from functools import lru_cache
+import logging
 import re
 from typing import Any, Callable, Dict, List, Tuple, Union
-
-# cisagov Libraries
-from chirp.common import ERROR
 
 
 @lru_cache(maxsize=128)
@@ -26,7 +24,7 @@ def OPERATOR_MAP(symbol: str) -> Union[Callable, None]:
     try:
         return d[symbol]
     except KeyError:
-        ERROR("Unknown symbol '{}'.".format(symbol))
+        logging.error("(OPERATORS) Unknown symbol '{}'.".format(symbol))
 
 
 def navigate_structure(item: Dict[str, Any], keys: List[str] = []) -> Any:
@@ -61,8 +59,8 @@ def parse_operator_and_operand(search_string: str) -> Union[Tuple[Any, Any], Non
     try:
         s = search_string.split(" ")
     except AttributeError:
-        ERROR(
-            "search string '{}' appears to be the wrong data type.".format(
+        logging.error(
+            "(OPERATORS) search string '{}' appears to be the wrong data type.".format(
                 search_string
             )
         )
@@ -71,7 +69,9 @@ def parse_operator_and_operand(search_string: str) -> Union[Tuple[Any, Any], Non
         operator = OPERATOR_MAP(s[0])
         operand = " ".join(s[1:])
     except IndexError:
-        ERROR("Did not receive a parseable string! '{}'".format(search_string))
+        logging.error(
+            "(OPERATORS) Did not receive a parseable string! '{}'".format(search_string)
+        )
         return
     if operand in NONE_TYPES:
         operand = ""

--- a/chirp/plugins/registry/registry.py
+++ b/chirp/plugins/registry/registry.py
@@ -1,10 +1,8 @@
 """Provides methods for parsing and retrieving registry entries."""
 
 # Standard Python Libraries
+import logging
 from typing import Iterator, Tuple
-
-# cisagov Libraries
-from chirp.common import CONSOLE
 
 HAS_LIBS = False
 try:
@@ -14,7 +12,6 @@ try:
     HAS_LIBS = True
 except ImportError:
     pass
-
 
 if HAS_LIBS:
 
@@ -80,7 +77,7 @@ if HAS_LIBS:
         """
         hive, key = _normalize_key(hkey)
         if not hive or not key:
-            CONSOLE("[red][!][/red] Unable to read key '{}'".format(hkey))
+            logging.log(61, "Unable to read key '{}'".format(hkey))
             return
         registry = winreg.ConnectRegistry(None, hive)
         try:
@@ -93,7 +90,7 @@ if HAS_LIBS:
                         "registry_type": REGISTRY_VALUE_TYPES[value_tuple[2]],
                     }
         except FileNotFoundError:
-            CONSOLE("[cyan][REGISTRY][/cyan] Key {} does not exist.".format(hkey))
+            logging.log(61, "Key {} does not exist.".format(hkey))
 
 
 else:
@@ -106,5 +103,5 @@ else:
         :yield: Literally "ERROR"
         :rtype: Iterator[str]
         """
-        CONSOLE("[red][!][/red] Registry plugin is only compatible with Windows.")
+        logging.log(61, "Registry plugin is only compatible with Windows.")
         yield "ERROR"

--- a/chirp/plugins/registry/scan.py
+++ b/chirp/plugins/registry/scan.py
@@ -2,11 +2,12 @@
 
 # Standard Python Libraries
 import json
+import logging
 import os
 from typing import Dict, List, Tuple, Union
 
 # cisagov Libraries
-from chirp.common import CONSOLE, OUTPUT_DIR, build_report
+from chirp.common import OUTPUT_DIR, build_report
 from chirp.plugins import operators
 from chirp.plugins.registry.registry import enumerate_registry_values
 
@@ -43,10 +44,8 @@ async def check_matches(
 
 async def _report_hits(indicator: str, vals: dict) -> None:
     """Write to the log the number of hits for a given indicator."""
-    CONSOLE(
-        "[cyan][REGISTRY][/cyan] Found {} hit(s) for {} indicator.".format(
-            len(vals["matches"]), indicator
-        )
+    logging.log(
+        61, "Found {} hit(s) for {} indicator.".format(len(vals["matches"]), indicator)
     )
 
 
@@ -58,15 +57,15 @@ async def run(indicators: dict) -> None:
     """
     if not indicators:
         return
-    CONSOLE("[cyan][REGISTRY][/cyan] Entered registry plugin.")
+    logging.debug("(REGISTRY) Entered registry plugin.")
     report = {indicator["name"]: build_report(indicator) for indicator in indicators}
     for indicator in indicators:
         ind = indicator["indicator"]
         indicator_list = [(k, v) for k, v in ind.items() if k != "registry_key"]
-        CONSOLE("[cyan][REGISTRY][/cyan] Reading {}".format(ind["registry_key"]))
+        logging.log(61, "Reading {}".format(ind["registry_key"]))
         async for value in enumerate_registry_values(ind["registry_key"]):
             if value == "ERROR":
-                CONSOLE("[cyan][REGISTRY][/cyan] Hit an error, exiting.")
+                logging.log(61, "Hit an error, exiting.")
                 return
             hits, search_criteria, match = await check_matches(indicator_list, value)
             if hits != len(indicator_list):

--- a/chirp/run.py
+++ b/chirp/run.py
@@ -2,12 +2,13 @@
 
 # Standard Python Libraries
 import asyncio
+import logging
 import os
 from typing import Callable, Dict, Iterable, Iterator, List
 
 # cisagov Libraries
 from chirp import load
-from chirp.common import CRITICAL, DEBUG, ERROR, OUTPUT_DIR, PLUGINS
+from chirp.common import OUTPUT_DIR, PLUGINS
 from chirp.plugins import events, loader, network, registry, yara  # noqa: F401
 
 
@@ -70,12 +71,12 @@ def check_valid_indicator_types(
     for indicator in indicator_generator:
         if indicator["ioc_type"] in plugins:
             yield indicator
-            DEBUG("Loaded {}".format(indicator["name"]))
+            logging.debug("Loaded {}".format(indicator["name"]))
         else:
             if (indicator["ioc_type"] in plugins or "all" in plugins) and indicator[
                 "ioc_type"
             ] not in failed_types:
-                ERROR(
+                logging.error(
                     """Can't locate plugin "{}". It is possible it has not loaded due to an error.""".format(
                         indicator["ioc_type"]
                     )
@@ -95,6 +96,6 @@ def get_indicators() -> Iterator[str]:
             if "README" not in f and f.split(".")[-1] in ("yaml", "yml"):
                 yield os.path.join("indicators", f)
     except FileNotFoundError:
-        CRITICAL(
+        logging.error(
             "Could not find an indicators directory. Indicators should be in the same directory as this executable."
         )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Add `--silent` switch to silence CHIRP output.
- Add `-v` switch to increase verbose-ness of program
- Replace custom logging method with `logging` builtin library (preps for #31)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Addition of a `--silent` switch allows an entirely non-interactive run of CHIRP if the `--non-interactive` switch is also invoked. Perfect for runs of CHIRP over distributed methods.

 Addition of a `-v` switch allows users to increase the verboseness of the program in a way that is more familiar, no custom log levels.

 The previous notes and the replacement of the custom logging method with the `logging` builtin library prepares for changes necessary to implement #31.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested in dev environment:
- Windows 10
- Python 3.8
- VSCode

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
