### PR TITLE
Non-zero Exit on IOC's Discovered in Non-interactive Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ python3 chirp.py -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
            [+] Done! Your results can be found at Z:\README\output.
 ```
 
-## Non-interactive Mode
+### Non-interactive Mode
 
 Non-interactive mode may be used by issuing the "--non-interactive" flag at runtime. Using this flag enables process completion without input. In addition, a non-zero status of 1 will be emitted at runtime completion if IoC's were discovered.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ python3 chirp.py -p registry yara -t c:\\target_dir\\** -o chirp_result -l debug
            [+] Done! Your results can be found at Z:\README\output.
 ```
 
+## Non-interactive Mode
+
+Non-interactive mode may be used by issuing the "--non-interactive" flag at runtime. Using this flag enables process completion without input. In addition, a non-zero status of 1 will be emitted at runtime completion if IoC's were discovered.
+
 ## ⛏️ Built Using <a name = "built_using"></a>
 
 - [Python](https://www.Python.org/) - Language

--- a/chirp.py
+++ b/chirp.py
@@ -21,8 +21,6 @@ if __name__ == "__main__":
             "DONE! Your results can be found in {}".format(os.path.abspath(OUTPUT_DIR)),
         )
         iocs_discovered = iocs_discovered()
-        # sleep to account for console interval
-        time.sleep(2)
         save_log()
         # non-zero exit if ioc's discovered and non_interactive mode enabled
         if NON_INTERACTIVE and iocs_discovered:

--- a/chirp.py
+++ b/chirp.py
@@ -9,7 +9,7 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import OUTPUT_DIR, save_log, wait
+from chirp.common import NON_INTERACTIVE, OUTPUT_DIR, iocs_discovered, save_log, wait
 
 if __name__ == "__main__":
     try:
@@ -20,10 +20,18 @@ if __name__ == "__main__":
             70,
             "DONE! Your results can be found in {}".format(os.path.abspath(OUTPUT_DIR)),
         )
-        wait()
+        iocs_discovered = iocs_discovered()
+        # sleep to account for console interval
+        time.sleep(2)
         save_log()
-        sys.exit(0)
+        # non-zero exit if ioc's discovered and non_interactive mode enabled
+        if NON_INTERACTIVE and iocs_discovered:
+            sys.exit(1)
+        else:
+            wait()
+            sys.exit(0)
     except KeyboardInterrupt:
         logging.error("Received an escape sequence. Goodbye.")
         save_log()
-        sys.exit(0)
+        # indicate abnormal exit with 2
+        sys.exit(2)

--- a/chirp/__main__.py
+++ b/chirp/__main__.py
@@ -21,8 +21,6 @@ if __name__ == "__main__":
             "DONE! Your results can be found in {}".format(os.path.abspath(OUTPUT_DIR)),
         )
         iocs_discovered = iocs_discovered()
-        # sleep to account for console interval
-        time.sleep(2)
         save_log()
         # non-zero exit if ioc's discovered and non_interactive mode enabled
         if NON_INTERACTIVE and iocs_discovered:

--- a/chirp/__main__.py
+++ b/chirp/__main__.py
@@ -9,7 +9,7 @@ import time
 
 # cisagov Libraries
 from chirp import run
-from chirp.common import OUTPUT_DIR, save_log, wait
+from chirp.common import NON_INTERACTIVE, OUTPUT_DIR, iocs_discovered, save_log, wait
 
 if __name__ == "__main__":
     try:
@@ -18,14 +18,20 @@ if __name__ == "__main__":
         time.sleep(2)
         logging.log(
             70,
-            "DONE! Your results can be found in {}.".format(
-                os.path.abspath(OUTPUT_DIR)
-            ),
+            "DONE! Your results can be found in {}".format(os.path.abspath(OUTPUT_DIR)),
         )
-        wait()
+        iocs_discovered = iocs_discovered()
+        # sleep to account for console interval
+        time.sleep(2)
         save_log()
-        sys.exit(0)
+        # non-zero exit if ioc's discovered and non_interactive mode enabled
+        if NON_INTERACTIVE and iocs_discovered:
+            sys.exit(1)
+        else:
+            wait()
+            sys.exit(0)
     except KeyboardInterrupt:
         logging.error("Received an escape sequence. Goodbye.")
         save_log()
-        sys.exit(0)
+        # indicate abnormal exit with 2
+        sys.exit(2)

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -58,6 +58,8 @@ if ARGS.verbose >= 2:
     LOG_LEVEL = logging.NOTSET
 elif ARGS.verbose == 1:
     LOG_LEVEL = logging.INFO
+elif NON_INTERACTIVE:
+    LOG_LEVEL = 70
 else:
     LOG_LEVEL = logging.ERROR
 

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -152,9 +152,9 @@ def iocs_discovered() -> bool:
         with open(report_file, "r") as f:
             data = json.load(f)
             if len(data) > 0:
-                logging.error(
-                    "Discovered IoC's, please see output reports for more details."
+                logging.log(
+                    70, "Discovered IoC's, please see output reports for more details."
                 )
                 return True
-    logging.info("No IoC's discovered!")
+    logging.log(70, "No IoC's discovered!")
     return False

--- a/chirp/common.py
+++ b/chirp/common.py
@@ -3,6 +3,8 @@
 # Standard Python Libraries
 import argparse
 import ctypes
+import glob
+import json
 import logging
 import os
 import sys
@@ -50,6 +52,7 @@ ARGS, _ = parser.parse_known_args()
 OUTPUT_DIR = ARGS.output
 PLUGINS = ARGS.plugins
 TARGETS = ARGS.targets
+NON_INTERACTIVE = ARGS.non_interactive
 
 if ARGS.verbose >= 2:
     LOG_LEVEL = logging.NOTSET
@@ -140,3 +143,18 @@ def wait() -> None:
         else:
             os.system('read -s -n 1 -p "Press any key to continue..."')  # nosec
             print()
+
+
+def iocs_discovered() -> bool:
+    """Determine whether iocs were discovered."""
+    report_files = glob.glob("{}/*".format(OUTPUT_DIR))
+    for report_file in report_files:
+        with open(report_file, "r") as f:
+            data = json.load(f)
+            if len(data) > 0:
+                logging.error(
+                    "Discovered IoC's, please see output reports for more details."
+                )
+                return True
+    logging.info("No IoC's discovered!")
+    return False


### PR DESCRIPTION
# Non-zero Exit on IOC's Discovered in Non-interactive Mode #

## 🗣 Description ##

Seeks IOC detection count from run and exits with non-zero status in non-interactive mode, retaining existing functionality in interactive mode. Addresses #31 

## 💭 Motivation and context ##

Common tooling in automatic workflows involves using non-zero exit codes to enable decision making after process completion. Using additional exit codes enhances CISA CHIRP's ability to be used within these contexts.

## 🧪 Testing ##

Used pre-commit to ensure proper conformance with linting and style.

Used the following against the code related to this PR to test various scenarios:
```shell
# non-interactive mode with non-zero exit (CHIRP self-detects IOC's when targeting itself)
python chirp.py -p yara -t c:\\chirp\\** -o chirp_result -l debug --non-interactive

# non-interactive mode with zero exit (no detections)
python chirp.py -p yara -t c:\\no_ioc_dir\\** -o chirp_result -l debug --non-interactive

# interactive mode with zero exit after prompt
python chirp.py -p yara -t c:\\no_ioc_dir\\** -o chirp_result -l debug
```

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
